### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/src/main/java/de/beimax/spacealert/mission/Announcement.java
+++ b/src/main/java/de/beimax/spacealert/mission/Announcement.java
@@ -58,6 +58,7 @@ public class Announcement implements Event {
 		case ANNOUNCEMENT_PH3_ONEMINUTE: return 5;
 		case ANNOUNCEMENT_PH3_TWENTYSECS: return 5;
 		case ANNOUNCEMENT_PH3_ENDS: return 12;
+		default: break;
 		}
 		return -1; //error
 	}
@@ -77,6 +78,7 @@ public class Announcement implements Event {
 		case ANNOUNCEMENT_PH3_ONEMINUTE: return "Operation ends in one minute.";
 		case ANNOUNCEMENT_PH3_TWENTYSECS: return "Operation ends in twenty seconds.";
 		case ANNOUNCEMENT_PH3_ENDS: return "Operation ends in 5, 4, 3, 2, 1. Mission complete.";
+		default: break;
 		}
 		return "ERROR"; //error
 	}
@@ -103,6 +105,7 @@ public class Announcement implements Event {
 		case ANNOUNCEMENT_PH3_ONEMINUTE: return "operation_ends_in_1_minute.mp3";
 		case ANNOUNCEMENT_PH3_TWENTYSECS: return "operation_ends_in_20_seconds.mp3";
 		case ANNOUNCEMENT_PH3_ENDS: return "operation_ends.mp3";
+		default: break;
 		}
 		return null;
 	}
@@ -124,6 +127,7 @@ public class Announcement implements Event {
 		case ANNOUNCEMENT_PH3_ONEMINUTE: sb.append("AnnounceThirdPhaseEndsInOneMinute"); break;
 		case ANNOUNCEMENT_PH3_TWENTYSECS: sb.append("AnnounceThirdPhaseEndsInTwentySeconds"); break;
 		case ANNOUNCEMENT_PH3_ENDS: sb.append("AnnounceThirdPhaseEnds"); break;
+		default: break;
 		}
 		sb.append('"');
 		return sb.toString();
@@ -138,6 +142,7 @@ public class Announcement implements Event {
 		case ANNOUNCEMENT_PH1_ENDS: return "1";
 		case ANNOUNCEMENT_PH2_ENDS: return "2";
 		case ANNOUNCEMENT_PH3_ENDS: return "3";
+		default: break;
 		}
 		return null;
 	}

--- a/src/main/java/de/beimax/spacealert/mission/Threat.java
+++ b/src/main/java/de/beimax/spacealert/mission/Threat.java
@@ -239,6 +239,7 @@ public class Threat implements Event {
 			case THREAT_SECTOR_BLUE: sb.append("blue"); break;
 			case THREAT_SECTOR_WHITE: sb.append("white"); break;
 			case THREAT_SECTOR_RED: sb.append("red"); break;
+			default: break;
 			}
 		}		
 		sb.append(".mp3");
@@ -270,6 +271,7 @@ public class Threat implements Event {
 			case THREAT_SECTOR_BLUE: sb.append("Blue"); break;
 			case THREAT_SECTOR_WHITE: sb.append("White"); break;
 			case THREAT_SECTOR_RED: sb.append("Red"); break;
+			default: break;
 			}
 			sb.append('"');
 		}
@@ -302,6 +304,7 @@ public class Threat implements Event {
 			case THREAT_SECTOR_BLUE: sb.append('B'); break;
 			case THREAT_SECTOR_WHITE: sb.append('W'); break;
 			case THREAT_SECTOR_RED: sb.append('R'); break;
+			default: break;
 			}
 		}		
 		return sb.toString();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat