### PR TITLE
squid:S2325, findbugs:DM_NUMBER_CTOR - private methods that don't acc…

### DIFF
--- a/src/main/java/de/beimax/spacealert/exec/CommandLine.java
+++ b/src/main/java/de/beimax/spacealert/exec/CommandLine.java
@@ -159,7 +159,7 @@ public class CommandLine extends Thread {
 	 * check for the existence of the clip directory
 	 * @return
 	 */
-	private boolean checkForClipDirectory(String folder) {
+	private static boolean checkForClipDirectory(String folder) {
 		File file = new File(folder);
 		if (!file.exists() || !file.isDirectory()) return false;
 		return true;

--- a/src/main/java/de/beimax/spacealert/exec/Gui.java
+++ b/src/main/java/de/beimax/spacealert/exec/Gui.java
@@ -188,7 +188,7 @@ public class Gui extends JFrame implements ActionListener {
 	 * check for the existence of the clip directory
 	 * @return true if directory exists
 	 */
-	private boolean checkForClipDirectory(String folder) {
+	private static boolean checkForClipDirectory(String folder) {
 		File file = new File(folder);
 		if (!file.exists() || !file.isDirectory()) return false;
 		return true;

--- a/src/main/java/de/beimax/spacealert/mission/EventList.java
+++ b/src/main/java/de/beimax/spacealert/mission/EventList.java
@@ -86,7 +86,7 @@ public class EventList {
 		if (!checkTime(time, event.getLengthInSeconds())) return false;
 		
 		// otherwise add event
-		events.put(new Integer(time), event);
+		events.put(Integer.valueOf(time), event);
 		return true;
 	}
 	

--- a/src/main/java/de/beimax/spacealert/mission/MissionImpl.java
+++ b/src/main/java/de/beimax/spacealert/mission/MissionImpl.java
@@ -333,7 +333,7 @@ public class MissionImpl implements Mission {
 		
 		// phases
 		ArrayList<Integer> phaseOne = new ArrayList<Integer>(4);
-		for (int i = 1; i <= 4; i++) phaseOne.add(new Integer(i));
+		for (int i = 1; i <= 4; i++) phaseOne.add(Integer.valueOf(i));
 		ArrayList<Integer> phaseTwo = new ArrayList<Integer>(4);
 		for (int i = 5; i <= 8; i++) phaseTwo.add(new Integer(i));
 		

--- a/src/main/java/de/beimax/spacealert/mp3/MP3Cache.java
+++ b/src/main/java/de/beimax/spacealert/mp3/MP3Cache.java
@@ -100,7 +100,7 @@ public class MP3Cache {
 	 * @param in
 	 * @return
 	 */
-	private ByteBuffer resizeBuffer(ByteBuffer in) {
+	private static ByteBuffer resizeBuffer(ByteBuffer in) {
 		ByteBuffer result = in;
 		if (in.remaining() < READ_BLOCK) {
 			// create new buffer


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2325 - "private" methods that don't access instance data should be "static"
findbugs:DM_NUMBER_CTOR - Performance - Method invokes inefficient Number constructor; use static valueOf instead

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
https://dev.eclipse.org/sonar/coding_rules#q=findbugs:DM_NUMBER_CTOR

Please let me know if you have any questions.

M-Ezzat
