### PR TITLE
Max Normal/Serious Threats options

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,12 @@ Start with: java -jar JSpaceAlertMissionGenerator.jar
     --max-internal-threats
       Maximum number of internal threats
       Default: 2
+    --max-normal-threats
+      Maximum number of normal threats.
+      Default: threat level minus 1 (not only normal threats)
+    --max-serious-threats
+      Maximum number of serious threats
+      Default: threat level minus 1, divided by 2, rounded down. (not only serious threats)
     --max-phase-time-1
       Maximum phase time for phase 1
       Default: 240

--- a/src/main/java/de/beimax/spacealert/util/Options.java
+++ b/src/main/java/de/beimax/spacealert/util/Options.java
@@ -57,7 +57,11 @@ public class Options {
 		} catch (ParameterException e) {
 			return false;
 		}
-		
+
+		if (options.maxNormalThreatsNumber + options.maxSeriousThreatsNumber * 2 < options.threatLevel) {
+			System.out.println("Cannot reach threat level with given max normal/serious threats");
+			return false;
+		}
 		return true;
 	}
 	
@@ -171,6 +175,14 @@ public class Options {
 	public int maxInternalThreats = 3;
 	@Parameter(names = { "--max-internal-threats" }, description = "Maximum number of internal threats")
 	public int maxInternalThreatsNumber = 2; // number of internal threats max
+
+	/**
+	 * limiting the number of normal and serious threats
+	 */
+	@Parameter(names = { "--max-normal-threats" }, description = "Maximum number of normal threats")
+	public int maxNormalThreatsNumber = threatLevel - 1;
+	@Parameter(names = { "--max-serious-threats" }, description = "Maximum number of serious threats")
+	public int maxSeriousThreatsNumber = (int) Math.floor((float)(threatLevel - 1)/2);
 
 	/**
 	 * enable double threats - see "The New Frontier"


### PR DESCRIPTION
This is my attempt at implementing the ideas I had in the comment here: https://github.com/mkalus/JSpaceAlertMissionGenerator/issues/19

I decided to follow the syntax of the existing --max-internal-threats option. This adds the following two options:

```
    --max-normal-threats
      Maximum number of normal threats.
      Default: threat level minus 1 (not only normal threats)
    --max-serious-threats
      Maximum number of serious threats
      Default: threat level minus 1, divided by 2, rounded down. (not only serious threats)
```

I removed the checks for 8 or more normal threats and only serious threats as these can now better be handled using the two new options and their defaults.

I also removed the following line as I believe it is a bug:

```newThreat.setThreatLevel(Threat.THREAT_LEVEL_NORMAL);```

